### PR TITLE
Added recommended list support for LSPosed and EdXposed scope mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,6 +66,9 @@
         <meta-data
             android:name="xposedminversion"
             android:value="53" />
+        <meta-data
+                android:name="xposedscope"
+                android:resource="@array/scope"/>
 
         <provider
             android:name=".providers.SharedPrefsProvider"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,12 @@
     <string name="close">Close</string>
 
     <string name="xposed_module_desc">Enables Ambient Music in Pixel Ambient Services &amp; adds mods to control it.\nImportant: You MUST have the Magisk module installed AS WELL for this to work.</string>
+    <string-array name="scope">
+        <item>android</item>
+        <item>com.google.intelligence.sense</item>
+        <item>com.google.android.as</item>
+        <item>com.kieronquinn.app.ambientmusicmod</item>
+    </string-array>
 
     <!-- Nav bar -->
     <string name="menu_settings">Settings</string>


### PR DESCRIPTION
This is necessary since scope mode is the only option in LSPosed and there is no FAQ on this. After this change an FAQ is not required.
These apps will be listed as recommended:

![image](https://user-images.githubusercontent.com/30069380/132035310-23f05430-980c-47ff-b406-e957c1a440ff.png)
