### PR TITLE
2.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,8 @@ apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
 String DEFAULT_MANIFEST = "215:https://storage.googleapis.com/music-iq-db/updatable_ytm_db/20220612-030100/manifest.json"
 
-def tagName = '2.0.1'
+def tagName = '2.0.2'
+def version = 202
 
 def getKeystoreProperties() {
     def properties = new Properties()
@@ -40,7 +41,7 @@ android {
         applicationId "com.kieronquinn.app.ambientmusicmod"
         minSdk 28
         targetSdk 32
-        versionCode 201
+        versionCode version
         versionName tagName
 
         buildConfigField "String", "DEFAULT_MANIFEST", "\"" + DEFAULT_MANIFEST + "\""
@@ -69,6 +70,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         debug {
+            minifyEnabled false
+            signingConfig signingConfigs.release
             manifestPlaceholders = [usesCleartextTraffic:"true"]
         }
     }

--- a/app/release/output-metadata.json
+++ b/app/release/output-metadata.json
@@ -11,8 +11,8 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 200,
-      "versionName": "2.0",
+      "versionCode": 201,
+      "versionName": "2.0.1",
       "outputFile": "app-release.apk"
     }
   ],

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/components/navigation/Navigation.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/components/navigation/Navigation.kt
@@ -134,6 +134,9 @@ suspend fun NavHostFragment.setupWithNavigation(navigation: BaseNavigation) {
                 }
                 ProcessPhoenix.triggerRebirth(requireContext(), mainIntent)
             }
+            is NavigationEvent.ContextInjectedMethod -> {
+                it.method.invoke(requireContext())
+            }
         }
     }
 }

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/DeviceConfigRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/DeviceConfigRepository.kt
@@ -23,6 +23,7 @@ interface DeviceConfigRepository {
     val recordingGain: AmbientMusicModSetting<Float>
     val showAlbumArt: AmbientMusicModSetting<Boolean>
     val enableLogging: AmbientMusicModSetting<Boolean>
+    val alternativeEncoding: AmbientMusicModSetting<Boolean>
 
     fun getAllDeviceConfigValues(): List<Pair<String, String>>
     suspend fun sendValues()
@@ -79,6 +80,10 @@ class DeviceConfigRepositoryImpl(
         private const val ENABLE_LOGGING = "NowPlaying__enable_logging"
         private const val ENABLE_LOGGING_DEFAULT = false
 
+        //Custom, enables BIG_ENDIAN encoding to fix crackle on some devices
+        private const val ALTERNATIVE_ENCODING = "NowPlaying__alternative_audio_encoding"
+        private const val ALTERNATIVE_ENCODING_DEFAULT = false
+
         private val KEY_MAP = mapOf(
             CACHE_SHARD_ENABLED to DeviceConfigRepositoryImpl::cacheShardEnabled,
             INDEX_MANIFEST to DeviceConfigRepositoryImpl::indexManifest,
@@ -90,7 +95,8 @@ class DeviceConfigRepositoryImpl(
             SUPERPACKS_REQUIRE_WIFI to DeviceConfigRepositoryImpl::superpacksRequireWiFi,
             RECORDING_GAIN to DeviceConfigRepositoryImpl::recordingGain,
             SHOW_ALBUM_ART to DeviceConfigRepositoryImpl::showAlbumArt,
-            ENABLE_LOGGING to DeviceConfigRepositoryImpl::enableLogging
+            ENABLE_LOGGING to DeviceConfigRepositoryImpl::enableLogging,
+            ALTERNATIVE_ENCODING to DeviceConfigRepositoryImpl::alternativeEncoding
         )
 
         /**
@@ -164,6 +170,10 @@ class DeviceConfigRepositoryImpl(
 
     override val enableLogging = boolean(
         ENABLE_LOGGING, ENABLE_LOGGING_DEFAULT, onChange
+    )
+
+    override val alternativeEncoding = boolean(
+        ALTERNATIVE_ENCODING, ALTERNATIVE_ENCODING_DEFAULT, onChange
     )
 
     override fun getAllDeviceConfigValues(): List<Pair<String, String>> {

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/RecognitionRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/RecognitionRepository.kt
@@ -136,6 +136,7 @@ class RecognitionRepositoryImpl(
         }
         val metadata = RecognitionCallbackMetadata(source, includeAudio)
         val service = getService() ?: run {
+            hasStarted = true
             trySend(RecognitionState.Error(ErrorReason.API_INCOMPATIBLE))
             close()
             return@callbackFlow

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/service/AmbientMusicModForegroundService.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/service/AmbientMusicModForegroundService.kt
@@ -440,14 +440,14 @@ class AmbientMusicModForegroundService: LifecycleService() {
         val launchIntent = Intent(this, MainActivity::class.java)
         val title = when(error.errorReason) {
             ErrorReason.SHIZUKU_ERROR -> R.string.notification_error_shizuku_title
-            ErrorReason.TIMEOUT -> R.string.notification_error_timeout_title
+            ErrorReason.TIMEOUT -> return
             ErrorReason.API_INCOMPATIBLE -> R.string.notification_error_api_title
             ErrorReason.NEEDS_ROOT -> R.string.notification_error_needs_root_title
             ErrorReason.DISABLED -> return
         }
         val subtitle = when(error.errorReason){
             ErrorReason.SHIZUKU_ERROR -> R.string.notification_error_shizuku_subtitle
-            ErrorReason.TIMEOUT -> R.string.notification_error_timeout_subtitle
+            ErrorReason.TIMEOUT -> return
             ErrorReason.API_INCOMPATIBLE -> R.string.notification_error_api_subtitle
             ErrorReason.NEEDS_ROOT -> R.string.notification_error_needs_root_subtitle
             ErrorReason.DISABLED -> return

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/service/ShizukuService.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/service/ShizukuService.kt
@@ -113,9 +113,12 @@ class ShizukuService: IShellProxy.Stub() {
 
     override fun AudioRecord_read(audioData: ByteArray, offsetInShorts: Int, sizeInShorts: Int): Int {
         val outShorts = ShortArray(sizeInShorts)
-        return audioRecord.read(outShorts, offsetInShorts, sizeInShorts).also {
+        val result = audioRecord.read(outShorts, offsetInShorts, sizeInShorts).also {
             outShorts.toByteArray().copyInto(audioData)
         }
+        val bufferSize = AudioRecord_getBufferSizeInFrames()
+        if(result <= 0) return result //Error or empty, don't process
+        return bufferSize
     }
 
     override fun AudioRecord_startRecording() {

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/recognition/RecognitionFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/recognition/RecognitionFragment.kt
@@ -477,6 +477,7 @@ class RecognitionFragment: BoundDialogFragment<FragmentRecognitionBinding>(Fragm
     }
 
     private fun runSuccess(state: State.Success) = with(binding.recognitionSuccess) {
+        root.bringToFront()
         binding.recognitionCircle.root.setImageResource(R.drawable.ic_recognition_circle_success)
         viewLifecycleOwner.lifecycleScope.launchWhenResumed {
             recognitionSuccessPlayback.onClicked().collect {
@@ -489,6 +490,7 @@ class RecognitionFragment: BoundDialogFragment<FragmentRecognitionBinding>(Fragm
     }
 
     private fun runFailed(state: State.Failed) = with(binding.recognitionFailed) {
+        root.bringToFront()
         binding.recognitionCircle.root.setImageResource(R.drawable.ic_recognition_circle_failed)
         prepFailed(state.result)
         viewLifecycleOwner.lifecycleScope.launchWhenResumed {
@@ -509,6 +511,7 @@ class RecognitionFragment: BoundDialogFragment<FragmentRecognitionBinding>(Fragm
     }
 
     private fun runError(state: State.Error) = with(binding.recognitionFailed) {
+        root.bringToFront()
         binding.recognitionCircle.root.setImageResource(R.drawable.ic_recognition_circle_failed)
         prepError(state.result)
         viewLifecycleOwner.lifecycleScope.launchWhenResumed {
@@ -522,6 +525,7 @@ class RecognitionFragment: BoundDialogFragment<FragmentRecognitionBinding>(Fragm
     }
 
     private fun runPlayback(state: State.Playback) = with(binding.recognitionPlayback) {
+        root.bringToFront()
         //Apply a gain just to the UI to make the waveform useful
         recognitionPlaybackWaveform.setRawData(state.audio.clone().applyGain(4f).toByteArray())
         recognitionPlaybackPlay.updatePlayingState(

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/settings/advanced/SettingsAdvancedFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/settings/advanced/SettingsAdvancedFragment.kt
@@ -59,6 +59,13 @@ class SettingsAdvancedFragment: BaseSettingsFragment(), BackAvailable {
             viewModel::onGainClicked
         ),
         GenericSettingsItem.SwitchSetting(
+            state.alternativeEncoding,
+            getString(R.string.settings_advanced_alternative_encoding),
+            getString(R.string.settings_advanced_alternative_encoding_content),
+            R.drawable.ic_settings_advanced_alternative_encoding,
+            onChanged = viewModel::onAlternativeEncodingChanged
+        ),
+        GenericSettingsItem.SwitchSetting(
             state.runOnSmallCores,
             getString(R.string.settings_advanced_small_cores),
             getString(R.string.settings_advanced_small_cores_content),

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Audio.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Audio.kt
@@ -1,19 +1,11 @@
 package com.kieronquinn.app.ambientmusicmod.utils.extensions
 
 import java.nio.ByteBuffer
-import java.nio.ByteOrder.LITTLE_ENDIAN
 
 fun ShortArray.toByteArray(): ByteArray {
     return ByteBuffer.allocate(size * 2).apply {
         asShortBuffer().put(this@toByteArray)
     }.array()
-}
-
-fun ByteArray.toShortArray(): ShortArray {
-    return ShortArray(this.size / 2).apply {
-        ByteBuffer.wrap(this@toShortArray)
-            .order(LITTLE_ENDIAN).asShortBuffer()[this]
-    }
 }
 
 fun ShortArray.applyGain(gain: Float): ShortArray {

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Flow.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Flow.kt
@@ -1,28 +1,10 @@
 package com.kieronquinn.app.ambientmusicmod.utils.extensions
 
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
-
-fun <T> Flow<T>.debounceIf(requirement: Boolean, time: Long): Flow<T> {
-    return this.debounce { _: T ->
-        if(requirement) time else 0L
-    }
-}
-
-fun tickerFlow(timePeriod: Long, initialDelay: Long) = flow {
-    delay(initialDelay)
-    while(true){
-        emit(Unit)
-        delay(timePeriod)
-    }
-}
-
-fun delayFlow(delay: Long) = flow {
-    delay(delay)
-    emit(Unit)
-}
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 
 suspend fun <T> Flow<T>.await(check: (T) -> Boolean): T {
     return first {
@@ -43,27 +25,3 @@ fun <T> Flow<T>.autoClearAfterBy(delay: suspend (T) -> Long?): Flow<T?> = channe
 suspend fun <T> Flow<T?>.firstNotNull(): T {
     return first { it != null }!!
 }
-
-@OptIn(InternalCoroutinesApi::class)
-suspend fun <T> Flow<T?>.collectUntilNull(flowCollector: FlowCollector<T>) =
-    takeWhile { it != null }.mapNotNull { it }.collect(flowCollector)
-
-inline fun <reified T> instantCombine(vararg flows: Flow<T>) = channelFlow {
-    val array = Array(flows.size) {
-        false to (null as T?)
-    }
-
-    flows.forEachIndexed { index, flow ->
-        launch {
-            flow.collect { emittedElement ->
-                array[index] = true to emittedElement
-                send(array.filter { it.first }.map { it.second })
-            }
-        }
-    }
-}
-
-suspend fun <T> Flow<T>.collectUntilTimeout(timeoutMillis: Long, collector: FlowCollector<T>) = mapLatest {
-    delay(timeoutMillis)
-    null
-}.collectUntilNull(collector)

--- a/app/src/main/res/drawable/ic_settings_advanced_alternative_encoding.xml
+++ b/app/src/main/res/drawable/ic_settings_advanced_alternative_encoding.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?android:textColorPrimary"
+        android:pathData="M14,2H6C4.9,2 4,2.9 4,4v16c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V8L14,2zM6,20V4h7v5h5v11H6zM16,11h-4v3.88c-0.36,-0.24 -0.79,-0.38 -1.25,-0.38c-1.24,0 -2.25,1.01 -2.25,2.25c0,1.24 1.01,2.25 2.25,2.25S13,17.99 13,16.75V13h3V11z" />
+</vector>

--- a/app/src/main/res/layout/fragment_settings_advanced_gain_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_settings_advanced_gain_bottom_sheet.xml
@@ -34,7 +34,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/margin_16"
         android:valueFrom="0.1"
-        android:valueTo="2.0"
+        android:valueTo="3.0"
         android:stepSize="0.05"
         app:layout_constraintBottom_toTopOf="@id/settings_advanced_gain_positive"
         app:layout_constraintTop_toBottomOf="@id/settings_advanced_gain_content" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,9 @@
     <string name="settings_advanced_gain_reset">Reset</string>
     <string name="settings_advanced_gain_formatter">%1sx</string>
 
+    <string name="settings_advanced_alternative_encoding">Use Alternative Encoding</string>
+    <string name="settings_advanced_alternative_encoding_content">Enable the use of an alternative encoding method which may fix distortion on some devices.\n<b>Note:</b> A higher gain value may be required in combination with this option</string>
+
     <string name="settings_advanced_small_cores">Run on Little Cores</string>
     <string name="settings_advanced_small_cores_content">Run recognition on the little CPU cores. May use less battery, may not work on all devices</string>
 


### PR DESCRIPTION
- Added alternative encoding option, fixing distortion/crackling on some devices when enabled
- Increased max gain to 3.0 to cope with new encoding which requires a higher gain on some devices
- Reduced the chance of audio recording errors
- Removed "Timeout" notification as it was more useless than it was useful
- Fixed unclickable Chips on Recognition Success page (eg. Ask Google)