### PR TITLE
release/2.2.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 String DEFAULT_MANIFEST = "247:https://storage.googleapis.com/music-iq-db/updatable_ytm_db/20230402-030031/manifest.json"
 String DEFAULT_MANIFEST_V3 = "3048:https://storage.googleapis.com/music-iq-db/updatable_db_v3/20230402-030031/manifest.json"
 
-def tagName = '2.2'
-def version = 220
+def tagName = '2.2.1'
+def version = 221
 
 def getKeystoreProperties() {
     def properties = new Properties()

--- a/app/release/output-metadata.json
+++ b/app/release/output-metadata.json
@@ -11,8 +11,8 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 220,
-      "versionName": "2.2",
+      "versionCode": 221,
+      "versionName": "2.2.1",
       "outputFile": "app-release.apk"
     }
   ],

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/UpdatesRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/UpdatesRepository.kt
@@ -192,7 +192,7 @@ class UpdatesRepositoryImpl(
     }
 
     private fun getUpdateCache(repository: String): GitHubRelease? {
-        val file = File(updatesCacheDir, repository)
+        val file = File(updatesCacheDir, "${repository}_${BuildConfig.VERSION_CODE}")
         if(!file.exists()) return null
         val cachedRelease = try {
             gson.fromJson(file.readText(), CachedGitHubRelease::class.java)
@@ -207,7 +207,7 @@ class UpdatesRepositoryImpl(
     }
 
     private fun GitHubRelease.cacheRelease(repository: String) {
-        val file = File(updatesCacheDir, repository)
+        val file = File(updatesCacheDir, "${repository}_${BuildConfig.VERSION_CODE}")
         val cachedRelease = gson.toJson(CachedGitHubRelease(System.currentTimeMillis(), this))
         file.writeText(cachedRelease)
     }

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/WidgetRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/WidgetRepository.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.TransactionTooLargeException
 import android.util.SizeF
 import android.view.LayoutInflater
 import android.view.View
@@ -199,9 +200,11 @@ class WidgetRepositoryImpl(
     private fun List<AppWidget>.sendLayouts(
         state: RecognitionState?, onDemandEnabled: Boolean
     ) = forEach {
-        appWidgetManager.updateAppWidget(
-            it.id, it.getRemoteViews(state, onDemandEnabled)
-        )
+        try {
+            appWidgetManager.updateAppWidget(it.id, it.getRemoteViews(state, onDemandEnabled))
+        }catch (e: TransactionTooLargeException) {
+            //Suppress, shouldn't happen unless system has lagged
+        }
     }
 
     private fun getRemoteView41(): RemoteViews {

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/updates/UpdatesViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/updates/UpdatesViewModel.kt
@@ -132,7 +132,7 @@ class UpdatesViewModelImpl(
     }.flowOn(Dispatchers.IO)
 
     private fun getPamState(clearCache: Boolean) = flow {
-        emit(updatesRepository.getPAMUpdateState(clearCache))
+        emit(updatesRepository.getPAMUpdateState(ignoreCache = clearCache))
     }.flowOn(Dispatchers.IO)
 
     private val downloadState = combine(


### PR DESCRIPTION
- Fixed cache for PAM not being skipped when swipe refreshed (#171)
- Tie local cache to AMM version so it is forcibly cleared after updating app version
- Suppress widget crash if system misbehaves (#169)