### PR TITLE
2.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,11 +12,11 @@ plugins {
 
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
-String DEFAULT_MANIFEST = "271:https://storage.googleapis.com/music-iq-db/updatable_ytm_db/20240331-030011/manifest.json"
-String DEFAULT_MANIFEST_V3 = "3079:https://storage.googleapis.com/music-iq-db/updatable_db_v3/20240324-040013/manifest.json"
+String DEFAULT_MANIFEST = "290:https://storage.googleapis.com/music-iq-db/updatable_ytm_db/20240901-030029/manifest.json"
+String DEFAULT_MANIFEST_V3 = "3099:https://storage.googleapis.com/music-iq-db/updatable_db_v3/20240901-030029/manifest.json"
 
-def tagName = '2.3.5'
-def version = 235
+def tagName = '2.4'
+def version = 240
 
 def getKeystoreProperties() {
     def properties = new Properties()
@@ -37,12 +37,12 @@ def getKeystoreProperties() {
 }
 
 android {
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "com.kieronquinn.app.ambientmusicmod"
         minSdk 28
-        targetSdk 34
+        targetSdk 35
         versionCode version
         versionName tagName
 
@@ -114,19 +114,21 @@ protobuf {
 
 dependencies {
     //AndroidX
-    implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.core:core-splashscreen:1.0.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
-    implementation "androidx.work:work-runtime-ktx:2.9.0"
+    implementation "androidx.work:work-runtime-ktx:2.9.1"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation "androidx.lifecycle:lifecycle-service:2.7.0"
+    implementation "androidx.lifecycle:lifecycle-service:2.8.5"
     implementation "androidx.security:security-crypto:1.1.0-alpha06"
+    implementation "androidx.fragment:fragment-ktx:1.8.3"
+    implementation "androidx.activity:activity-ktx:1.9.2"
 
     //Material UI
-    implementation 'com.google.android.material:material:1.12.0-rc01'
+    implementation 'com.google.android.material:material:1.12.0'
 
     //MonetCompat for colours on < S
     implementation 'com.github.KieronQuinn:MonetCompat:0.4.1'
@@ -138,7 +140,7 @@ dependencies {
     implementation "com.google.protobuf:protobuf-javalite:3.25.2"
 
     //Lottie for animations
-    implementation 'com.airbnb.android:lottie:6.3.0'
+    implementation 'com.airbnb.android:lottie:6.4.0'
 
     //Used for chip layouts
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
@@ -146,7 +148,7 @@ dependencies {
     //Audio visualisation during playback
     implementation 'com.github.alxrm:audiowave-progressbar:0.9.2'
 
-    implementation 'com.google.guava:guava:31.1-android'
+    implementation 'com.google.guava:guava:32.0.1-android'
     implementation 'com.google.code.gson:gson:2.10.1'
 
     //Update & APK downloading
@@ -161,6 +163,7 @@ dependencies {
 
     //Used to cleanly restart the app in full after setup
     implementation 'com.jakewharton:process-phoenix:2.1.2'
+    implementation 'androidx.core:core-remoteviews:1.1.0'
 
     //Stubs for system APIs (not included in APK)
     compileOnly project(path: ':systemstubs')
@@ -183,7 +186,7 @@ dependencies {
     kapt "com.google.dagger:hilt-compiler:2.50"
 
     //OSS libraries activity
-    implementation 'com.google.android.gms:play-services-oss-licenses:17.0.1'
+    implementation 'com.google.android.gms:play-services-oss-licenses:17.1.0'
 
     //Better Link Movement Method for inline links
     implementation 'me.saket:better-link-movement-method:2.2.0'
@@ -200,6 +203,6 @@ dependencies {
     ksp "androidx.room:room-compiler:$room_version"
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -154,6 +154,7 @@
         <!-- Dynamic widget (Android 12+) -->
         <receiver
             android:name=".providers.AmbientMusicModWidgetDynamic"
+            android:label="@string/widget_regular_label"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -169,6 +170,7 @@
         <!-- 4x1 widget (< Android 12) -->
         <receiver
             android:name=".providers.AmbientMusicModWidget41"
+            android:label="@string/widget_regular_label"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -181,6 +183,7 @@
         <!-- 4x2 widget (< Android 12) -->
         <receiver
             android:name=".providers.AmbientMusicModWidget42"
+            android:label="@string/widget_regular_label"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -188,6 +191,22 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/appwidgetprovider_42" />
+        </receiver>
+
+        <!-- Minimal Widget -->
+        <receiver
+            android:name=".providers.AmbientMusicModWidgetMinimal"
+            android:label="@string/widget_minimal_label"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/appwidgetprovider_minimal" />
+            <meta-data
+                android:name="com.samsung.android.appwidget.provider"
+                android:resource="@xml/samsung_widget" />
         </receiver>
 
         <provider

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/model/backup/SettingsBackup.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/model/backup/SettingsBackup.kt
@@ -69,5 +69,7 @@ data class SettingsBackup(
     @SerializedName("periodic_backup_enabled")
     val periodicBackupEnabled: Boolean?,
     @SerializedName("periodic_backup_interval")
-    val periodicBackupInterval: PeriodicBackupInterval?
+    val periodicBackupInterval: PeriodicBackupInterval?,
+    @SerializedName("overlay_shadow_enabled")
+    val overlayShadowEnabled: Boolean?
 )

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/providers/AmbientMusicModWidgetMinimal.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/providers/AmbientMusicModWidgetMinimal.kt
@@ -1,0 +1,3 @@
+package com.kieronquinn.app.ambientmusicmod.providers
+
+class AmbientMusicModWidgetMinimal: AmbientMusicModWidget()

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/BackupRestoreRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/BackupRestoreRepository.kt
@@ -344,7 +344,8 @@ class BackupRestoreRepositoryImpl(
             settingsRepository.lockscreenOverlayCustomColour.getOrNull(),
             deviceConfigRepository.alternativeEncoding.getOrNull(),
             settingsRepository.periodicBackupEnabled.getOrNull(),
-            settingsRepository.periodicBackupInterval.getOrNull()
+            settingsRepository.periodicBackupInterval.getOrNull(),
+            settingsRepository.lockscreenOverlayShadowEnabled.getOrNull()
         )
     }
 
@@ -385,6 +386,7 @@ class BackupRestoreRepositoryImpl(
         alternativeEncoding.restoreTo(deviceConfigRepository.alternativeEncoding)
         periodicBackupEnabled.restoreTo(settingsRepository.periodicBackupEnabled)
         periodicBackupInterval.restoreTo(settingsRepository.periodicBackupInterval)
+        overlayShadowEnabled.restoreTo(settingsRepository.lockscreenOverlayShadowEnabled)
     }
 
     private suspend fun <T> T?.restoreTo(setting: BaseSettingsRepository.AmbientMusicModSetting<T>) {

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/SettingsRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/repositories/SettingsRepository.kt
@@ -26,6 +26,7 @@ interface SettingsRepository {
     val lockscreenOverlayClicked: AmbientMusicModSetting<LockscreenOnTrackClicked>
     val lockscreenOverlayColour: AmbientMusicModSetting<OverlayTextColour>
     val lockscreenOverlayCustomColour: AmbientMusicModSetting<Int>
+    val lockscreenOverlayShadowEnabled: AmbientMusicModSetting<Boolean>
 
     val lockscreenOwnerInfo: AmbientMusicModSetting<Boolean>
     val lockscreenOwnerInfoShowNote: AmbientMusicModSetting<Boolean>
@@ -187,6 +188,9 @@ class SettingsRepositoryImpl(
 
         private const val LOCK_SCREEN_OVERLAY_CUSTOM_TEXT_COLOUR = "lock_screen_overlay_custom_text_colour"
 
+        private const val LOCK_SCREEN_OVERLAY_SHADOW = "lock_screen_overlay_shadow"
+        private const val DEFAULT_LOCK_SCREEN_OVERLAY_SHADOW = true
+
         private const val LOCK_SCREEN_OWNER_INFO = "lock_screen_owner_info"
         private const val DEFAULT_LOCK_SCREEN_OWNER_INFO = false
 
@@ -268,6 +272,10 @@ class SettingsRepositoryImpl(
 
     override val lockscreenOverlayCustomColour = color(
         LOCK_SCREEN_OVERLAY_CUSTOM_TEXT_COLOUR, Integer.MAX_VALUE
+    )
+
+    override val lockscreenOverlayShadowEnabled = boolean(
+        LOCK_SCREEN_OVERLAY_SHADOW, DEFAULT_LOCK_SCREEN_OVERLAY_SHADOW
     )
 
     override val lockscreenOwnerInfo = boolean(

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/service/AmbientMusicModForegroundService.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/service/AmbientMusicModForegroundService.kt
@@ -197,9 +197,10 @@ class AmbientMusicModForegroundService: LifecycleService() {
 
     private val screenOnTrigger = combine(
         broadcastReceiverAsFlow(Intent.ACTION_SCREEN_ON),
-        settings.triggerWhenScreenOn.asFlow()
-    ) { _, enabled ->
-        if(enabled) Unit else null
+        settings.triggerWhenScreenOn.asFlow(),
+        enabled
+    ) { _, enabled, mainEnabled ->
+        if(mainEnabled && enabled) Unit else null
     }.filterNotNull()
 
     private val overlayState = combine(

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/base/BoundFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/base/BoundFragment.kt
@@ -6,14 +6,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
-import androidx.fragment.app.Fragment
 import androidx.viewbinding.ViewBinding
 import com.google.android.material.transition.FadeThroughProvider
 import com.google.android.material.transition.MaterialSharedAxis
 import com.google.android.material.transition.SlideDistanceProvider
 import com.kieronquinn.app.ambientmusicmod.R
 import com.kieronquinn.monetcompat.app.MonetFragment
-import java.lang.NullPointerException
 import kotlin.math.roundToInt
 
 abstract class BoundFragment<V: ViewBinding>(private val inflate: (LayoutInflater, ViewGroup?, Boolean) -> V): MonetFragment() {

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/base/FragmentOptions.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/base/FragmentOptions.kt
@@ -6,7 +6,6 @@ import android.view.MenuItem
 
 interface BackAvailable
 interface LockCollapsed
-interface CanShowSnackbar
 interface NoToolbar
 
 interface Root

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/lockscreen/LockScreenFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/lockscreen/LockScreenFragment.kt
@@ -69,7 +69,20 @@ class LockScreenFragment: BaseSettingsFragment(), BackAvailable {
             R.drawable.ic_lock_screen_owner_info,
             onClick = viewModel::onOwnerInfoClicked
         )
-        if(!state.enabled) return listOf(switch, ownerInfo, LockScreenSettingsItem.Footer)
+        val textColour = GenericSettingsItem.Setting(
+            getString(R.string.lockscreen_overlay_text_colour_title),
+            getString(R.string.lockscreen_overlay_text_colour_content, state.overlayTextColour),
+            R.drawable.ic_lockscreen_overlay_text_colour,
+            onClick = viewModel::onTextColourClicked
+        )
+        val shadow = GenericSettingsItem.SwitchSetting(
+            state.overlayShadowEnabled,
+            getString(R.string.lockscreen_overlay_shadow_enabled_title),
+            getString(R.string.lockscreen_overlay_shadow_enabled_content),
+            R.drawable.ic_shadow,
+            onChanged = viewModel::onShadowChanged
+        )
+        if(!state.enabled) return listOf(switch, ownerInfo, textColour, shadow, LockScreenSettingsItem.Footer)
         val header = LockScreenSettingsItem.Header(
             state.style,
             viewModel::onStyleChanged,
@@ -91,12 +104,6 @@ class LockScreenFragment: BaseSettingsFragment(), BackAvailable {
             R.drawable.ic_lockscreen_click_action,
             onClick = viewModel::onClickActionClicked
         )
-        val textColour = GenericSettingsItem.Setting(
-            getString(R.string.lockscreen_overlay_text_colour_title),
-            getString(R.string.lockscreen_overlay_text_colour_content, state.overlayTextColour),
-            R.drawable.ic_lockscreen_overlay_text_colour,
-            onClick = viewModel::onTextColourClicked
-        )
         val onDemand = if(state.onDemandAvailable){
             GenericSettingsItem.SwitchSetting(
                 state.onDemandEnabled,
@@ -115,7 +122,7 @@ class LockScreenFragment: BaseSettingsFragment(), BackAvailable {
             ) {}
         }else null
         return listOfNotNull(
-            switch, header, enhancedSetting, clickAction, textColour, onDemand, ownerInfo, systemUi, LockScreenSettingsItem.Footer
+            switch, header, enhancedSetting, clickAction, textColour, shadow, onDemand, ownerInfo, systemUi, LockScreenSettingsItem.Footer
         )
     }
 

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/root/RootFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/ui/screens/root/RootFragment.kt
@@ -2,7 +2,6 @@ package com.kieronquinn.app.ambientmusicmod.ui.screens.root
 
 import android.os.Bundle
 import android.view.View
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.NavHostFragment
 import com.kieronquinn.app.ambientmusicmod.R
 import com.kieronquinn.app.ambientmusicmod.components.navigation.RootNavigation

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Context.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Context.kt
@@ -314,3 +314,5 @@ fun Context.isOnDemandConfigValueSet(): Boolean {
         "config_defaultMusicRecognitionService"
     ) == COMPONENT_GSA_ON_DEMAND
 }
+
+fun Context.dip(value: Int): Int = resources.dip(value)

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+IActivityManager.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+IActivityManager.kt
@@ -56,7 +56,7 @@ private fun IActivityManager.bindServiceInstanceCompat(
     callingPackage: String?,
     userId: Int
 ): Int {
-    return if (BuildCompat.isAtLeastT()) {
+    return try {
         bindServiceInstance(
             caller,
             token,
@@ -68,7 +68,7 @@ private fun IActivityManager.bindServiceInstanceCompat(
             callingPackage,
             userId
         )
-    } else {
+    } catch (e: NoSuchMethodError) {
         bindIsolatedService(
             caller,
             token,

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Navigation.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Navigation.kt
@@ -1,5 +1,6 @@
 package com.kieronquinn.app.ambientmusicmod.utils.extensions
 
+import androidx.activity.OnBackPressedCallback
 import androidx.navigation.NavController
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
@@ -14,3 +15,9 @@ fun NavController.onDestinationChanged() = callbackFlow {
         removeOnDestinationChangedListener(listener)
     }
 }.debounce(TAP_DEBOUNCE)
+
+fun NavController.setOnBackPressedCallback(callback: OnBackPressedCallback) {
+    NavController::class.java.getDeclaredField("onBackPressedCallback").apply {
+        isAccessible = true
+    }.set(this, callback)
+}

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+PackageManager.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+PackageManager.kt
@@ -16,10 +16,10 @@ fun PackageManager.isPermissionGranted(packageName: String, vararg permission: S
         return true
     }
     return packageInfo.requestedPermissions
-        .zip(packageInfo.requestedPermissionsFlags.toTypedArray())
-        .filter { permission.contains(it.first) }
-        .also { if(it.size != permission.size) return false } //Missing at least one permission
-        .all { it.second and PackageInfo.REQUESTED_PERMISSION_GRANTED != 0 }
+        ?.zip(packageInfo.requestedPermissionsFlags?.toTypedArray() ?: return false)
+        ?.filter { permission.contains(it.first) }
+        ?.also { if(it.size != permission.size) return false } //Missing at least one permission
+        ?.all { it.second and PackageInfo.REQUESTED_PERMISSION_GRANTED != 0 } == true
 }
 
 fun PackageManager.isAppInstalled(packageName: String): Boolean {

--- a/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Resources.kt
+++ b/app/src/main/java/com/kieronquinn/app/ambientmusicmod/utils/extensions/Extensions+Resources.kt
@@ -12,3 +12,5 @@ fun Resources.getResourceIdArray(@ArrayRes resourceId: Int): Array<Int> {
     array.recycle()
     return items.toTypedArray()
 }
+
+fun Resources.dip(value: Int): Int = (value * displayMetrics.density).toInt()

--- a/app/src/main/res/drawable/ic_shadow.xml
+++ b/app/src/main/res/drawable/ic_shadow.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M15.6,10.79c0.97,-0.67 1.65,-1.77 1.65,-2.79 0,-2.26 -1.75,-4 -4,-4L7,4v14h7.04c2.09,0 3.71,-1.7 3.71,-3.79 0,-1.52 -0.86,-2.82 -2.15,-3.42zM10,6.5h3c0.83,0 1.5,0.67 1.5,1.5s-0.67,1.5 -1.5,1.5h-3v-3zM13.5,15.5L10,15.5v-3h3.5c0.83,0 1.5,0.67 1.5,1.5s-0.67,1.5 -1.5,1.5z"
+        android:fillColor="?android:textColorPrimary"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:fitsSystemWindows="false">
 
@@ -10,6 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:id="@+id/fragment_root"
-        android:name="com.kieronquinn.app.ambientmusicmod.ui.screens.root.RootFragment"/>
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph_activity" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_root.xml
+++ b/app/src/main/res/layout/fragment_root.xml
@@ -11,6 +11,7 @@
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        app:defaultNavHost="true"
         tools:navGraph="@navigation/nav_graph_root" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/widget_minimal.xml
+++ b/app/src/main/res/layout/widget_minimal.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/widget_root"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    android:orientation="horizontal"
+    tools:layout_gravity="center">
+
+    <FrameLayout
+        android:layout_width="24dp"
+        android:layout_height="24dp">
+
+        <ProgressBar
+            android:id="@+id/widget_icon_recognised"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:indeterminateDrawable="@drawable/audioanim_animation_progress"
+            android:indeterminateTint="?android:textColorPrimary" />
+
+        <ProgressBar
+            android:id="@+id/widget_icon_no_music"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:indeterminateDrawable="@drawable/audioanim_no_music_progress"
+            android:indeterminateTint="?android:textColorPrimary"
+            android:visibility="gone" />
+
+        <ImageButton
+            android:id="@+id/widget_button_on_demand"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="@dimen/margin_8"
+            android:background="@null"
+            android:src="@drawable/ic_source_picker_on_demand"
+            android:tint="?android:textColorPrimary"
+            android:visibility="gone"
+            tools:ignore="UseAppTint" />
+
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_marginStart="@dimen/margin_8"
+        android:fontFamily="google-sans-text"
+        android:gravity="center_vertical"
+        android:shadowColor="?widgetShadowColour"
+        android:shadowDx="0.5"
+        android:shadowDy="0.5"
+        android:shadowRadius="0.5"
+        android:text="@string/item_nowplaying_header_preview"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small.AmbientMusicMod"
+        android:textColor="?android:textColorPrimary"
+        tools:fontFamily="@font/google_sans_text" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/widget_minimal_no_shadow.xml
+++ b/app/src/main/res/layout/widget_minimal_no_shadow.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:theme="@style/WidgetShadowDisabled">
+    <include layout="@layout/widget_minimal" />
+</LinearLayout>

--- a/app/src/main/res/layout/widget_minimal_shadow.xml
+++ b/app/src/main/res/layout/widget_minimal_shadow.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:theme="@style/WidgetShadowEnabled">
+    <include layout="@layout/widget_minimal" />
+</LinearLayout>

--- a/app/src/main/res/layout/widget_preview_minimal.xml
+++ b/app/src/main/res/layout/widget_preview_minimal.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:theme="@style/WidgetShadowEnabled">
+    <include layout="@layout/widget_minimal" />
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph_activity.xml
+++ b/app/src/main/res/navigation/nav_graph_activity.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_activity"
+    app:startDestination="@id/rootFragment">
+
+    <fragment
+        android:id="@+id/rootFragment"
+        android:name="com.kieronquinn.app.ambientmusicmod.ui.screens.root.RootFragment"
+        android:label="RootFragment" />
+</navigation>

--- a/app/src/main/res/navigation/nav_graph_now_playing.xml
+++ b/app/src/main/res/navigation/nav_graph_now_playing.xml
@@ -190,7 +190,7 @@
     <fragment
         android:id="@+id/lockScreenTextColourFragment"
         android:name="com.kieronquinn.app.ambientmusicmod.ui.screens.lockscreen.textcolour.LockScreenTextColourFragment"
-        android:label="@string/lockscreen_overlay_text_colour_title"
+        android:label="@string/lockscreen_overlay_text_colour_title_short"
         tools:layout="@layout/fragment_settings_base" >
         <action
             android:id="@+id/action_lockScreenTextColourFragment_to_lockScreenCustomTextColourFragment"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="WidgetShadow">
+        <attr name="widgetShadowColour" format="reference"/>
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
     <string name="item_nowplaying_notifications_title">Notifications</string>
     <string name="item_nowplaying_notifications_content_enabled">On</string>
     <string name="item_nowplaying_notifications_content_disabled">Off</string>
-    <string name="item_nowplaying_lockscreen_title">Lock Screen</string>
+    <string name="item_nowplaying_lockscreen_title">Lock Screen &amp; Widget</string>
     <string name="item_nowplaying_lockscreen_content">Display identified songs on your lock screen</string>
     <string name="item_nowplaying_ondemand_title">On Demand Recognition</string>
     <string name="item_nowplaying_ondemand_content">Identify songs playing nearby that aren\'t recognised by your device</string>
@@ -237,8 +237,11 @@
     <string name="lockscreen_owner_info_fallback_content_empty">[Empty]</string>
     <string name="lockscreen_owner_info_fallback_reset">Reset</string>
 
-    <string name="lockscreen_overlay_text_colour_title">Overlay Text Colour</string>
-    <string name="lockscreen_overlay_text_colour_content">Set the text colour of the lockscreen overlay: %1s</string>
+    <string name="lockscreen_overlay_text_colour_title">Overlay / Minimal Widget Text Colour</string>
+    <string name="lockscreen_overlay_text_colour_title_short">Text Colour</string>
+    <string name="lockscreen_overlay_text_colour_content">Set the text colour of the lockscreen overlay &amp; minimal widget: %1s</string>
+    <string name="lockscreen_overlay_shadow_enabled_title">Overlay / Minimal Widget Shadow</string>
+    <string name="lockscreen_overlay_shadow_enabled_content">Show a shadow behind the lockscreen overlay &amp; minimal widget\'s text for contrast against wallpapers</string>
 
     <string name="lockscreen_overlay_text_colour_automatic_title">Automatic</string>
     <string name="lockscreen_overlay_text_colour_automatic_content">Automatically adjusts to the wallpaper colour, provided by the system (may not work on all wallpapers)</string>
@@ -456,6 +459,8 @@
     <string name="widget_recognising">Recognising</string>
     <string name="widget_error">Error Recognising Music</string>
     <string name="widget_error_disabled">Recognition is disabled</string>
+    <string name="widget_regular_label">Now Playing</string>
+    <string name="widget_minimal_label">Now Playing (Minimal)</string>
 
     <!-- Setup -->
     <string name="landing_title">@string/app_name</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -100,4 +100,19 @@
         <item name="fontFamily">@font/google_sans_text</item>
     </style>
 
+    <style name="WidgetShadowEnabled" parent="Theme.MaterialComponents.DayNight">
+        <item name="widgetShadowColour">@android:color/black</item>
+    </style>
+
+    <style name="WidgetShadowDisabled" parent="Theme.MaterialComponents.DayNight">
+        <item name="widgetShadowColour">@android:color/transparent</item>
+    </style>
+
+    <style name="WidgetText" parent="@android:style/Widget.TextView">
+        <item name="android:shadowColor">?widgetShadowColour</item>
+        <item name="android:shadowDx">0.5</item>
+        <item name="android:shadowDy">0.5</item>
+        <item name="android:shadowRadius">0.5</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/xml/appwidgetprovider_minimal.xml
+++ b/app/src/main/res/xml/appwidgetprovider_minimal.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/widget_minimal_shadow"
+    android:minWidth="280dp"
+    android:minHeight="40dp"
+    android:minResizeWidth="180dp"
+    android:minResizeHeight="40dp"
+    android:widgetCategory="home_screen|keyguard"
+    android:previewLayout="@layout/widget_preview_minimal"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="4"
+    android:targetCellHeight="1" />

--- a/astrea/build.gradle
+++ b/astrea/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
     id 'com.google.protobuf'
+    id 'com.google.devtools.ksp'
 }
 
 android {
@@ -64,35 +65,35 @@ protobuf {
 
 dependencies {
     //AndroidX for basic (mainly Annotations), Room and LifecycleService
-    def room_version = "2.5.1"
+    def room_version = "2.6.1"
     implementation "androidx.room:room-runtime:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
-    implementation 'androidx.core:core-ktx:1.10.0'
-    implementation "androidx.lifecycle:lifecycle-service:2.6.1"
+    ksp "androidx.room:room-compiler:$room_version"
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation "androidx.lifecycle:lifecycle-service:2.8.5"
 
     //gRPC for comms + annotations for compiled code
     implementation 'io.grpc:grpc-android:1.54.0'
     implementation 'io.grpc:grpc-binder:1.54.0'
-    implementation 'io.grpc:grpc-stub:1.54.0'
+    implementation 'io.grpc:grpc-stub:1.57.0'
     implementation 'io.grpc:grpc-okhttp:1.54.0'
-    implementation 'io.grpc:grpc-protobuf-lite:1.54.0'
+    implementation 'io.grpc:grpc-protobuf-lite:1.57.0'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
     //okhttp for networking
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 
     //Flogger for logging
     implementation 'com.google.flogger:flogger:0.7.4'
     implementation 'com.google.flogger:google-extensions:0.7.4'
 
     //Dagger + Hilt for injection
-    implementation "com.google.dagger:hilt-android:2.38.1"
-    implementation 'com.google.dagger:dagger:2.41'
-    kapt 'com.google.dagger:dagger-compiler:2.41'
-    kapt "com.google.dagger:hilt-compiler:2.41"
+    implementation "com.google.dagger:hilt-android:2.50"
+    implementation 'com.google.dagger:dagger:2.50'
+    kapt 'com.google.dagger:dagger-compiler:2.50'
+    kapt "com.google.dagger:hilt-compiler:2.50"
 
     //Other Google requirements
-    implementation "com.google.guava:guava:31.1-android"
+    implementation "com.google.guava:guava:32.0.1-android"
     kapt 'com.google.auto.value:auto-value:1.9'
     compileOnly 'com.jakewharton.auto.value:auto-value-annotations:1.4'
     implementation 'com.ryanharter.auto.value:auto-value-parcel:0.2.5'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.nav_version = "2.7.7"
+    ext.nav_version = "2.8.0"
     ext.protobufVersion = '0.9.4'
     ext.shizuku_version = '13.1.5'
     ext.refine_version = '4.4.0'
@@ -16,12 +16,12 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.3.1' apply false
-    id 'com.android.library' version '8.3.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
+    id 'com.android.application' version '8.5.2' apply false
+    id 'com.android.library' version '8.5.2' apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.20' apply false
     id 'com.google.dagger.hilt.android' version '2.41' apply false
     id 'dev.rikka.tools.refine' version '4.1.0' apply false
-    id 'com.google.devtools.ksp' version '1.9.22-1.0.17' apply false
+    id 'com.google.devtools.ksp' version '2.0.20-1.0.25' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Feb 03 19:53:48 GMT 2024
+#Sat Sep 07 17:33:51 BST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/systemstubs/build.gradle
+++ b/systemstubs/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.10.0'
+    implementation 'androidx.core:core-ktx:1.13.1'
 
     annotationProcessor "dev.rikka.tools.refine:annotation-processor:$refine_version"
     compileOnly "dev.rikka.tools.refine:annotation:$refine_version"


### PR DESCRIPTION
- Added new "minimal" widget in the style of the lock screen overlay (requires Android 12 or above). This is ideal for use on devices which support lock screen widgets, instead of using the overlay. This can be configured in the same lock screen settings as the current options.
- Added option to disable the shadow for the overlay & new widget
- Enabled in-app predictive back where possible
- Fixed an issue where the screen on recognition trigger could be invoked while the main toggle was disabled
- Fixed a suppressed crash when using On Demand recognition on some devices, which was causing the recognition to appear to get stuck
- Various bug fixes